### PR TITLE
Migrate project testing and docs to SQLite for Azure deployment

### DIFF
--- a/MyPostgresApi.csproj
+++ b/MyPostgresApi.csproj
@@ -20,7 +20,6 @@
 
     <!-- HealthChecks -->
     <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="9.0.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
@@ -46,9 +45,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-
-    <!-- PostgreSQL provider (latest stable is 8.0.4, no 9.x stable yet) -->
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
 
     <!-- ASP.NET Core -->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />

--- a/MyPostgresApi.csproj
+++ b/MyPostgresApi.csproj
@@ -12,12 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Metrics -->
-    <PackageReference Include="App.Metrics" Version="4.4.0-preview.0.4" />
-    <PackageReference Include="App.Metrics.AspNetCore" Version="4.4.0-preview.0.10" />
-    <PackageReference Include="App.Metrics.AspNetCore.Tracking" Version="4.4.0-preview.0.10" />
-    <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="4.4.0-preview.0.10" />
-
     <!-- HealthChecks -->
     <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
@@ -53,7 +47,6 @@
 
     <!-- Other -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
 
     <!-- Test packages -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/README.md
+++ b/README.md
@@ -108,14 +108,15 @@ dotnet test
 5. Upload an existing `app.db` (if you migrated data) by using `az webapp ssh` or the
    Kudu console. Place the database at `/home/site/wwwroot/app.db`.
 
-The application exposes health checks at `/health` and `/health-ui`, and Prometheus
-metrics if you keep the existing monitoring setup.
+The application exposes health checks at `/health` and `/health-ui`.
 
 ## Observability endpoints
 
 * `GET /health` – machine-readable health check (includes SQLite health probe)
 * `GET /health-ui` – HealthChecks.UI dashboard (disabled in test environment)
-* `GET /metrics` – Prometheus/App.Metrics endpoint (requires authentication in production)
+
+Azure App Service surfaces platform metrics through Azure Monitor, so no additional
+Prometheus endpoint is exposed by this API.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -1,84 +1,125 @@
+# MyPostgresApi
+
+An ASP.NET Core 8 Web API that manages users, saved images and public board posts. The
+application now ships with Entity Framework Core + SQLite so that it can run on a
+single-file database when hosted on Azure App Service or other PaaS platforms.
+
+## Project layout
+
+```
 MyPostgresApi/
-├── Controllers/
-│   ├── UsersController.cs
-│   └── SavedImagescontroller.cs
-├── Data/
-│   ├── AppDbContext.cs
-│   └── test.http
-├── Models/
-│   ├── SavedImage.cs
-│   ├── ChangePasswordRequest.cs
-│   └── User.cs
-├── DTOs/
-│   ├── UserDto.cs
-│   └── SavedImagesDto.cs
-├── Tests/
-│   ├── Assemblyinfo.cs
-│   ├── ImagesTest.cs
-│   ├──  UsersTest
-│   └── CustomWebApplicationFactory.cs
-├── appsettings.json
-├── .env
-├── .env.test
-├── Program.cs
-└── MyPostgresApi.csproj
+├── Controllers/          # API endpoints for users, saved images and board posts
+├── Data/                 # EF Core DbContext
+├── DTOs/                 # Request/response models
+├── Migrations/           # SQLite schema migrations
+├── Models/               # Domain models
+├── Scripts/              # Utility SQL/DDL scripts for SQLite
+├── Tests/                # xUnit integration tests (run against SQLite)
+└── Program.cs            # ASP.NET Core host configuration
+```
 
-Metrics with http://172.105.95.18:9090/
+## Prerequisites
 
-You can try: application_httprequests_transactions,
+* .NET 8 SDK
+* SQLite 3 (for inspecting the generated database file)
+* Optional: Azure CLI (`az`) for deployment
 
-and then hit:
-execute
+## Local development
 
-Select graph for visual layout.
+1. Restore packages and build the solution:
+   ```bash
+   dotnet restore
+   dotnet build
+   ```
+2. Create an `.env` file (copy from `.env.example` if you have one) and set:
+   ```bash
+   JWT_SECRET_KEY=replace-with-a-strong-secret
+   SQLITE_PATH=app.db             # optional – defaults to app.db in the project root
+   PORT=8080                      # optional – defaults to 8080 which matches Azure App Service Linux
+   ```
+3. Apply migrations. This creates `app.db` locally:
+   ```bash
+   dotnet ef database update
+   ```
+4. Run the API:
+   ```bash
+   dotnet run
+   ```
+5. Navigate to `http://localhost:8080/swagger` for interactive docs.
 
-And as admin you can try:
-http://172.105.95.18:3000/ or http://172.105.95.18:3000/d/UDdpyzz7z/prometheus-2-0-stats?orgId=1&from=now-1h&to=now&timezone=browser&refresh=1m
+## Running the test suite
 
-for Grafana
+The integration tests now run against a temporary SQLite database:
 
-____________________________________________________________________________________________
+```bash
+dotnet test
+```
 
-The connection strings are on the server in appsettings.json/appsettings.Development.json
+## Migrating data from PostgreSQL to SQLite
 
-SQL:
+1. **Export from PostgreSQL (on Linode):**
+   ```bash
+   pg_dump "postgres://user:password@linode-host:5432/database" \
+     --schema=maskinen --data-only --column-inserts \
+     --table=users --table=saved_images --table=board_posts \
+     > postgres-data.sql
+   ```
+2. **Create a fresh SQLite database locally:**
+   ```bash
+   dotnet ef database update
+   ```
+3. **Import the dump into SQLite:**
+   *Install `pgloader` (or `sqlite-utils` from Python) on your workstation, then run one
+   of the tools to translate PostgreSQL inserts into SQLite format.* For example using
+   `pgloader`:
+   ```lisp
+   load database
+     from postgresql://user:password@localhost/database
+     into sqlite:///app.db
+     with include drop, create tables, create indexes;
+   ```
+   Alternatively, use the provided `Scripts/create_board_posts_table.sql` to create tables
+   manually and import CSV files via the `sqlite3` shell (`.mode csv`, `.import ...`).
+4. **Copy `app.db` to your Azure deployment** (see next section). The application runs
+   migrations at startup, so any future schema changes will be applied automatically.
 
-CREATE TABLE IF NOT EXISTS maskinen.users (
-    id SERIAL PRIMARY KEY,
-    name TEXT,
-    email TEXT UNIQUE NOT NULL,
-    password TEXT NOT NULL
-);
+## Deploying to Azure App Service (Linux)
 
-CREATE TABLE IF NOT EXISTS maskinen.saved_images (
-	id SERIAL PRIMARY KEY,
-	user_id INTEGER NOT NULL,
-	image_url TEXT NOT NULL,
-	title TEXT,
-	photographer TEXT,
-	source_link TEXT,
-	saved_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
-	CONSTRAINT fk_user FOREIGN KEY (user_id)
-		REFERENCES maskinen.users (id)
-		ON DELETE CASCADE
-);
+1. Publish the application:
+   ```bash
+   dotnet publish -c Release -o publish
+   ```
+2. Create Azure resources:
+   ```bash
+   az group create --name MyPostgresApi-rg --location westeurope
+   az appservice plan create --name MyPostgresApi-plan --resource-group MyPostgresApi-rg --sku B1 --is-linux
+   az webapp create --resource-group MyPostgresApi-rg --plan MyPostgresApi-plan --name <your-webapp-name> --runtime "DOTNET:8.0"
+   ```
+3. Configure application settings so the Web App knows where the SQLite file lives:
+   ```bash
+   az webapp config appsettings set \
+     --resource-group MyPostgresApi-rg --name <your-webapp-name> \
+     --settings JWT_SECRET_KEY="<strong-secret>" SQLITE_PATH="/home/site/wwwroot/app.db"
+   ```
+4. Deploy the published artifacts:
+   ```bash
+   az webapp deploy --resource-group MyPostgresApi-rg --name <your-webapp-name> --src-path publish
+   ```
+5. Upload an existing `app.db` (if you migrated data) by using `az webapp ssh` or the
+   Kudu console. Place the database at `/home/site/wwwroot/app.db`.
 
-CREATE TABLE IF NOT EXISTS test_schema.users (
-    id SERIAL PRIMARY KEY,
-    name TEXT,
-    email TEXT UNIQUE NOT NULL,
-    password TEXT NOT NULL
-); 
+The application exposes health checks at `/health` and `/health-ui`, and Prometheus
+metrics if you keep the existing monitoring setup.
 
-CREATE TABLE IF NOT EXISTS test_schema.saved_images (
-	id SERIAL PRIMARY KEY,
-	user_id INTEGER NOT NULL,
-	image_url TEXT NOT NULL,
-	title TEXT,
-	photographer TEXT,
-	source_link TEXT,
-	saved_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
-	CONSTRAINT fk_user FOREIGN KEY (user_id)
-		REFERENCES test_schema.users (id)
-		ON DELETE CASCADE
-);
+## Observability endpoints
+
+* `GET /health` – machine-readable health check (includes SQLite health probe)
+* `GET /health-ui` – HealthChecks.UI dashboard (disabled in test environment)
+* `GET /metrics` – Prometheus/App.Metrics endpoint (requires authentication in production)
+
+## Resources
+
+* `Scripts/create_board_posts_table.sql` – SQLite schema snippet if you need to create
+  tables manually.
+* `app.db` – default SQLite database file generated during development. Delete it if you
+  prefer to recreate from migrations.

--- a/Scripts/create_board_posts_table.sql
+++ b/Scripts/create_board_posts_table.sql
@@ -1,23 +1,18 @@
--- Create board_posts table for production schema
-CREATE TABLE IF NOT EXISTS maskinen.board_posts (
-    id SERIAL PRIMARY KEY,
-    name VARCHAR(255),
-    message TEXT,
-    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
-    user_id INTEGER NOT NULL,
-    CONSTRAINT fk_board_post_user FOREIGN KEY (user_id)
-        REFERENCES maskinen.users (id)
-        ON DELETE CASCADE
+-- SQLite DDL for board_posts table when manual provisioning is required
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE,
+    password TEXT NOT NULL
 );
 
--- Create board_posts table for test schema
-CREATE TABLE IF NOT EXISTS test_schema.board_posts (
-    id SERIAL PRIMARY KEY,
-    name VARCHAR(255),
+CREATE TABLE IF NOT EXISTS board_posts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
     message TEXT,
-    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
+    created_at TEXT DEFAULT (datetime('now')),
     user_id INTEGER NOT NULL,
-    CONSTRAINT fk_board_post_user FOREIGN KEY (user_id)
-        REFERENCES test_schema.users (id)
-        ON DELETE CASCADE
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );

--- a/Tests/BoardTests.cs
+++ b/Tests/BoardTests.cs
@@ -26,8 +26,7 @@ public class BoardPostsTest : IClassFixture<CustomWebApplicationFactory>, IAsync
 
     public async Task InitializeAsync()
     {
-        await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.board_posts RESTART IDENTITY CASCADE");
-        await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.users RESTART IDENTITY CASCADE");
+        await ResetDatabaseAsync();
 
         var user = new User
         {
@@ -56,9 +55,17 @@ public class BoardPostsTest : IClassFixture<CustomWebApplicationFactory>, IAsync
 
     public async Task DisposeAsync()
     {
-        await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.board_posts RESTART IDENTITY CASCADE");
-        await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.users RESTART IDENTITY CASCADE");
+        await ResetDatabaseAsync();
         _scope.Dispose();
+    }
+
+    private async Task ResetDatabaseAsync()
+    {
+        await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM board_posts;");
+        await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM saved_images;");
+        await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM users;");
+        await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM sqlite_sequence WHERE name IN ('board_posts','saved_images','users');");
+        _dbContext.ChangeTracker.Clear();
     }
 
     [Fact]

--- a/Tests/CustomWebApplicationFactory.cs
+++ b/Tests/CustomWebApplicationFactory.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using System.IO;
+using System.Linq;
 
 public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 {
@@ -7,87 +9,37 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
     {
         builder.UseEnvironment("Testing");
 
-        // Set the content root to the project directory
         var projectDir = Directory.GetCurrentDirectory();
         builder.UseContentRoot(projectDir);
 
-        builder.ConfigureAppConfiguration((context, configBuilder) =>
-        {
-            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["DB_SCHEMA"] = "test_schema"
-            });
-
-            configBuilder.AddJsonFile("appsettings.Test.json", optional: true);
-            configBuilder.AddEnvironmentVariables();
-        });
-
         builder.ConfigureServices(services =>
         {
-            // Remove existing AppDbContext registration
             var descriptor = services.SingleOrDefault(
                 d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
             if (descriptor != null)
+            {
                 services.Remove(descriptor);
+            }
 
-            // Read test database connection string
-            var testConn = Environment.GetEnvironmentVariable("TEST_DB_CONNECTION");
-            if (string.IsNullOrWhiteSpace(testConn))
-                throw new Exception("❌ TEST_DB_CONNECTION is missing or empty!");
+            var testDbPath = Path.Combine(Path.GetTempPath(), "mypostgresapi-tests.db");
+            Environment.SetEnvironmentVariable("SQLITE_PATH", testDbPath);
 
-            // Add test AppDbContext
+            var jwtSecret = Environment.GetEnvironmentVariable("JWT_SECRET_KEY");
+            if (string.IsNullOrWhiteSpace(jwtSecret))
+            {
+                Environment.SetEnvironmentVariable("JWT_SECRET_KEY", "insecure-test-secret-change-me");
+            }
+
             services.AddDbContext<AppDbContext>(options =>
-                options.UseNpgsql(testConn));
+                options.UseSqlite($"Data Source={testDbPath}"));
 
-            // Build service provider and initialize database
             var sp = services.BuildServiceProvider();
+
             using var scope = sp.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
-            try
-            {
-                var verbose = Environment.GetEnvironmentVariable("VERBOSE_TEST_LOGS") == "true";
-
-                if (verbose)
-                    Console.WriteLine($"🔌 DB Connection: {db.Database.GetDbConnection().ConnectionString}");
-
-                // Force EF to create schema and tables from model
-                db.Database.EnsureCreated();
-
-                if (verbose)
-                {
-                    var tables = db.Model.GetEntityTypes().Select(e => e.GetTableName()).Distinct();
-                    Console.WriteLine("📦 Tables registered with EF:");
-                    foreach (var t in tables)
-                        Console.WriteLine($" - {t}");
-                }
-
-                // Validate required tables
-                string[] expectedTables = { "users", "saved_images", "board_posts" };
-                foreach (var table in expectedTables)
-                {
-                    try
-                    {
-                        db.Database.ExecuteSqlRaw($"SELECT 1 FROM test_schema.{table} LIMIT 1;");
-                        if (verbose)
-                            Console.WriteLine($"✅ Table test_schema.{table} exists");
-                    }
-                    catch
-                    {
-                        Console.WriteLine($"❌ Missing: test_schema.{table}");
-                    }
-                }
-
-                // Truncate test tables
-                db.Database.ExecuteSqlRaw("TRUNCATE TABLE test_schema.users RESTART IDENTITY CASCADE");
-                db.Database.ExecuteSqlRaw("TRUNCATE TABLE test_schema.saved_images RESTART IDENTITY CASCADE");
-                db.Database.ExecuteSqlRaw("TRUNCATE TABLE test_schema.board_posts RESTART IDENTITY CASCADE");
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"❌ Error initializing test schema: {ex.Message}");
-                throw;
-            }
+            db.Database.EnsureDeleted();
+            db.Database.EnsureCreated();
         });
     }
 }

--- a/Tests/ImagesTest.cs
+++ b/Tests/ImagesTest.cs
@@ -24,8 +24,7 @@ namespace MyPostgresApi.Tests
 
         public async Task InitializeAsync()
         {
-            await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.saved_images RESTART IDENTITY CASCADE");
-            await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.users RESTART IDENTITY CASCADE");
+            await ResetDatabaseAsync();
 
             var user = new
             {
@@ -42,9 +41,17 @@ namespace MyPostgresApi.Tests
 
         public async Task DisposeAsync()
         {
-            await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.saved_images RESTART IDENTITY CASCADE");
-            await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.users RESTART IDENTITY CASCADE");
+            await ResetDatabaseAsync();
             _scope.Dispose();
+        }
+
+        private async Task ResetDatabaseAsync()
+        {
+            await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM board_posts;");
+            await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM saved_images;");
+            await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM users;");
+            await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM sqlite_sequence WHERE name IN ('board_posts','saved_images','users');");
+            _dbContext.ChangeTracker.Clear();
         }
 
         private async Task<string> GetJwtTokenAsync(string email, string password)

--- a/Tests/UsersTest.cs
+++ b/Tests/UsersTest.cs
@@ -25,8 +25,7 @@ namespace MyPostgresApi.Tests
         // ✅ This runs before each test
         public async Task InitializeAsync()
         {
-            await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.saved_images RESTART IDENTITY CASCADE");
-            await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.users RESTART IDENTITY CASCADE");
+            await ResetDatabaseAsync();
 
             // Create a test user
             var newUser = new
@@ -46,9 +45,17 @@ namespace MyPostgresApi.Tests
         // ✅ This runs after each test
         public async Task DisposeAsync()
         {
-            await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.saved_images RESTART IDENTITY CASCADE");
-            await _dbContext.Database.ExecuteSqlRawAsync("TRUNCATE TABLE test_schema.users RESTART IDENTITY CASCADE");
+            await ResetDatabaseAsync();
             _scope.Dispose();
+        }
+
+        private async Task ResetDatabaseAsync()
+        {
+            await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM board_posts;");
+            await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM saved_images;");
+            await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM users;");
+            await _dbContext.Database.ExecuteSqlRawAsync("DELETE FROM sqlite_sequence WHERE name IN ('board_posts','saved_images','users');");
+            _dbContext.ChangeTracker.Clear();
         }
 
         private async Task<string> GetJwtTokenAsync()


### PR DESCRIPTION
## Summary
- update the documentation with SQLite-first local setup, PostgreSQL-to-SQLite migration steps, and Azure App Service deployment guidance
- switch the integration-test infrastructure to SQLite and remove dependencies on PostgreSQL
- drop PostgreSQL-specific packages and adjust auxiliary SQL scripts to target SQLite

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7f878b1388327b93aa2ff8f99860a

## Summary by Sourcery

Migrate the project to use SQLite for local development, testing, and Azure App Service deployment by updating documentation, scripts, and test infrastructure accordingly

Enhancements:
- Reorganize project structure to include EF Core SQLite migrations and a Scripts folder for manual DDL
- Switch integration-test infrastructure from PostgreSQL to a temporary SQLite database

Documentation:
- Update README with SQLite-first local setup, EF migrations, PostgreSQL-to-SQLite migration steps, and Azure App Service deployment instructions
- Replace PostgreSQL DDL scripts with SQLite schema snippets in Scripts/create_board_posts_table.sql

Tests:
- Configure CustomWebApplicationFactory to initialize and clean up a temporary SQLite database for integration tests
- Refactor tests to use a ResetDatabaseAsync helper instead of PostgreSQL truncate commands

Chores:
- Remove PostgreSQL-specific packages, environment variables, and auxiliary SQL scripts targeting test_schema