### PR TITLE
Fix health check UI endpoint to avoid hard-coded port

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -43,7 +43,7 @@ if (!builder.Environment.IsEnvironment("Testing"))
     builder.Services.AddHealthChecksUI(options =>
     {
         options.SetEvaluationTimeInSeconds(15);
-        options.AddHealthCheckEndpoint("API Health", "http://localhost:5019/health");
+        options.AddHealthCheckEndpoint("API Health", "/health");
     }).AddInMemoryStorage();
 }
 


### PR DESCRIPTION
## Summary
- update the health checks UI endpoint configuration to use the app's `/health` route instead of a hard-coded port

## Testing
- `PORT=8080 dotnet run` *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da73fd115883278685701346ca9230

## Summary by Sourcery

Enhancements:
- Use relative /health endpoint for HealthChecksUI instead of http://localhost:5019/health