### PR TITLE
Modernize CI/CD pipeline for Azure App Service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,32 +2,17 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [Linode]
+    branches: [Azure]
   pull_request:
-    branches: [Linode]
+    branches: [Azure]
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -39,57 +24,34 @@ jobs:
 
       - name: Build
         run: dotnet build --no-restore
-       
-      - name: Print TEST_DB_CONNECTION for sanity check
-        run: |
-          echo "🔍 TEST_DB_CONNECTION preview:"
-          echo "Host=localhost;Port=5432;Username=postgres;***;Database=postgres;Search Path=test_schema"
-      
+
       - name: Run Tests
-        run: dotnet test
-        env:
-          DB_HOST: 127.0.0.1
-          DB_PORT: 5432
-          DB_NAME: postgres
-          DB_USER: postgres
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          TEST_DB_CONNECTION: Host=localhost;Port=5432;Username=postgres;Password=${{ secrets.DB_PASSWORD }};Database=postgres;Search Path=test_schema
-          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+        run: dotnet test --no-build
+
+      - name: Publish application
+        run: dotnet publish -c Release -o ./publish
+
+      - name: Upload published artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mypostgresapi-publish
+          path: ./publish
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build-and-test  # <--- This makes sure "deploy" only runs if "build-and-test" succeeds
+    needs: build-and-test
+    if: github.event_name == 'push'
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v4
+        with:
+          name: mypostgresapi-publish
+          path: ./publish
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '8.0.408' 
-
-    - name: Publish application
-      run: dotnet publish -c Release -o ./publish
-
-    - name: Debug SSH setup
-      env:
-        SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      run: |
-        mkdir -p ~/.ssh
-        echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
-        ssh-keyscan -H 172.105.95.18 >> ~/.ssh/known_hosts
-        ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no root@172.105.95.18 "echo 'SSH connection successful'"
-
-    - name: Deploy to server
-      env:
-        SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      run: |
-        scp -r ./publish/* root@172.105.95.18:/var/www/MyPostgresApi
-
-    - name: Restart MyPostgresApi service
-      env:
-        SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      run: |
-        ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no root@172.105.95.18 "sudo systemctl restart MyPostgresApi"
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: ./publish

--- a/README.md
+++ b/README.md
@@ -110,6 +110,30 @@ dotnet test
 
 The application exposes health checks at `/health` and `/health-ui`.
 
+## GitHub Actions deployment pipeline
+
+The `.github/workflows/deploy.yml` workflow now runs on pushes and pull requests that
+target the `Azure` branch. It restores dependencies, builds the solution, runs the test
+suite against SQLite, publishes the application, and saves the published output as a
+pipeline artifact. On branch pushes, the deploy job downloads that artifact and deploys
+it to Azure App Service via the `azure/webapps-deploy@v3` action.
+
+### Required GitHub secrets
+
+Add the following repository secrets so the workflow can authenticate with Azure and
+target the correct Web App:
+
+| Secret | Description |
+| ------ | ----------- |
+| `AZURE_WEBAPP_NAME` | The name of the Azure Web App that hosts this API. |
+| `AZURE_WEBAPP_PUBLISH_PROFILE` | The base64-encoded publish profile for the Web App. Download it from the Azure Portal (`Get publish profile`) and paste the entire XML into the secret. |
+| `AZURE_WEBAPP_SLOT` (optional) | Name of the deployment slot if you deploy somewhere other than Production. When set, also update the workflow input. |
+
+The publish profile includes the resource group, credentials, and FTP endpoints required
+for deployment, so no additional secrets are necessary. Ensure the App Service has the
+`JWT_SECRET_KEY` and `SQLITE_PATH` application settings configured as described above so
+the deployed application can start successfully.
+
 ## Observability endpoints
 
 * `GET /health` – machine-readable health check (includes SQLite health probe)


### PR DESCRIPTION
## Summary
- update the CI workflow to run on the Azure branch, build/test with SQLite, publish artifacts, and deploy via Azure Web Apps
- document the required GitHub secrets and pipeline behavior for the Azure deployment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7418517483278219d76b62a0390a

## Summary by Sourcery

Modernize the CI/CD pipeline to target Azure App Service, streamline build and test, and document deployment requirements.

Enhancements:
- Switch workflow triggers from the Linode branch to the Azure branch for push and pull_request events
- Remove Postgres service from CI and run tests against SQLite with streamlined build-and-test steps
- Upgrade GitHub Actions steps (actions/checkout@v4, setup-dotnet@v4) and add publish/upload-artifact in build job and download-artifact in deploy job
- Replace SSH-based Linode deployment with azure/webapps-deploy@v3 to deploy the published artifact to Azure App Service

Documentation:
- Update README with CI/CD workflow details and list required GitHub secrets for Azure App Service deployment